### PR TITLE
Check dangling dollar symbol in markdown block

### DIFF
--- a/test/fixtures/default.txt
+++ b/test/fixtures/default.txt
@@ -146,4 +146,12 @@ $$
 .
 <p class="katex-block katex-error" title="\f
 ">ParseError: KaTeX parse error: Undefined control sequence: \f at position 1: \̲f̲
-</p>.
+</p>
+.
+
+Delimiter in markdown block
+.
+<code>$x</code> `${a}`
+.
+<p>&lt;code&gt;$x&lt;/code&gt; <code>${a}</code></p>
+.


### PR DESCRIPTION
This PR aims to fix [#138970](https://github.com/microsoft/vscode/issues/138970). When checking if a $ is a valid inline delimiter, this PR adds a check for whether a $ is the first or last in a markdown block.
```
<code>$x</code> `${a}`
```
Now the second $ in the example above will not be treated as an inline math block closer.