### PR TITLE
Add support to render math defined inside html

### DIFF
--- a/index.js
+++ b/index.js
@@ -379,6 +379,8 @@ module.exports = function math_plugin(md, options) {
     options = options || {};
 
     const enableBareBlocks = options.enableBareBlocks;
+    const enableMathBlockInHtml = options.enableMathBlockInHtml;
+    const enableMathInlineInHtml = options.enableMathInlineInHtml;
 
     const katexInline = (latex) => {
         const displayMode = /\\begin\{(align|equation|gather|cd|alignat)\}/ig.test(latex);
@@ -421,6 +423,76 @@ module.exports = function math_plugin(md, options) {
     }, {
         alt: ['paragraph', 'reference', 'blockquote', 'list']
     });
+
+    // Regex to capture any html prior to math block, the math block (single or multi line), and any html after the math block
+    const math_block_within_html_regex = /(?<html_before_math>[\s\S]*?)\$\$(?<math>[\s\S]+?)\$\$(?<html_after_math>(?:(?!\$\$[\s\S]+?\$\$)[\s\S])*)/gm;
+
+    // Regex to capture any html prior to math inline, the math inline (single line), and any html after the math inline
+    const math_inline_within_html_regex = /(?<html_before_math>[\s\S]*?)\$(?<math>.*?)\$(?<html_after_math>(?:(?!\$.*?\$)[\s\S])*)/gm;
+
+    md.core.ruler.push("math_block_in_html_block", (state) => {  
+        if (!enableMathBlockInHtml) {    
+            return false;
+        }
+        return handleMathInHtml(state, "math_block", "$$", math_block_within_html_regex);
+    });
+
+    md.core.ruler.after("math_block_in_html_block", "math_inline_in_html_block", (state) => {     
+        if (!enableMathInlineInHtml) {    
+            return false;
+        }
+        return handleMathInHtml(state, "math_inline", "$", math_inline_within_html_regex);
+    });
+
+    // For any html block that contains math, replace the html block token with new tokens that separate out
+    // the html blocks from the math
+    const handleMathInHtml = (state, mathType, mathMarkup, mathRegex,) => {
+        const tokens = state.tokens;
+
+        for (let index = tokens.length - 1; index >= 0; index--) {
+            const currentToken = tokens[index];
+            const newTokens = [];
+
+            if (currentToken.type !== "html_block") {
+                continue;
+            }
+
+            const content = currentToken.content;
+
+            // Process for each math referenced within the html block
+            for (const match of content.matchAll(mathRegex)) {
+                const html_before_math = match.groups.html_before_math;
+                const math = match.groups.math;
+                const html_after_math = match.groups.html_after_math;
+
+                if (html_before_math) {
+                    newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_before_math });
+                }
+
+                if (math) {
+                    newTokens.push({ 
+                        ...currentToken,
+                        type: mathType,
+                        map: null,
+                        content: math,
+                        markup: mathMarkup,
+                        block: true,
+                        tag: "math",
+                    });
+                }
+
+                if (html_after_math) {
+                    newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_after_math });
+                }
+            }    
+            
+            // Replace the original html_block token with the newly expanded tokens
+            if (newTokens.length > 0) {
+                tokens.splice(index, 1, ...newTokens);
+            }
+        }    
+        return true;
+    }
 
     md.renderer.rules.math_inline = inlineRenderer;
     md.renderer.rules.math_inline_block = blockRenderer;

--- a/index.js
+++ b/index.js
@@ -364,6 +364,56 @@ function inlineBareBlock(state, silent) {
     return true;
 }
 
+// For any html block that contains math, replace the html block token with new tokens that separate out
+// the html blocks from the math
+function handleMathInHtml(state, mathType, mathMarkup, mathRegex) {
+    const tokens = state.tokens;
+
+    for (let index = tokens.length - 1; index >= 0; index--) {
+        const currentToken = tokens[index];
+        const newTokens = [];
+
+        if (currentToken.type !== "html_block") {
+            continue;
+        }
+
+        const content = currentToken.content;
+
+        // Process for each math referenced within the html block
+        for (const match of content.matchAll(mathRegex)) {
+            const html_before_math = match.groups.html_before_math;
+            const math = match.groups.math;
+            const html_after_math = match.groups.html_after_math;
+
+            if (html_before_math) {
+                newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_before_math });
+            }
+
+            if (math) {
+                newTokens.push({ 
+                    ...currentToken,
+                    type: mathType,
+                    map: null,
+                    content: math,
+                    markup: mathMarkup,
+                    block: true,
+                    tag: "math",
+                });
+            }
+
+            if (html_after_math) {
+                newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_after_math });
+            }
+        }    
+        
+        // Replace the original html_block token with the newly expanded tokens
+        if (newTokens.length > 0) {
+            tokens.splice(index, 1, ...newTokens);
+        }
+    }    
+    return true;
+}
+
 function escapeHtml(unsafe) {
     return unsafe
         .replace(/&/g, "&amp;")
@@ -430,68 +480,16 @@ module.exports = function math_plugin(md, options) {
     // Regex to capture any html prior to math inline, the math inline (single line), and any html after the math inline
     const math_inline_within_html_regex = /(?<html_before_math>[\s\S]*?)\$(?<math>.*?)\$(?<html_after_math>(?:(?!\$.*?\$)[\s\S])*)/gm;
 
-    md.core.ruler.push("math_block_in_html_block", (state) => {  
-        if (!enableMathBlockInHtml) {    
-            return false;
-        }
-        return handleMathInHtml(state, "math_block", "$$", math_block_within_html_regex);
-    });
+    if (enableMathBlockInHtml) {   
+        md.core.ruler.push("math_block_in_html_block", (state) => {
+            return handleMathInHtml(state, "math_block", "$$", math_block_within_html_regex);
+        });
+    }
 
-    md.core.ruler.after("math_block_in_html_block", "math_inline_in_html_block", (state) => {     
-        if (!enableMathInlineInHtml) {    
-            return false;
-        }
-        return handleMathInHtml(state, "math_inline", "$", math_inline_within_html_regex);
-    });
-
-    // For any html block that contains math, replace the html block token with new tokens that separate out
-    // the html blocks from the math
-    const handleMathInHtml = (state, mathType, mathMarkup, mathRegex,) => {
-        const tokens = state.tokens;
-
-        for (let index = tokens.length - 1; index >= 0; index--) {
-            const currentToken = tokens[index];
-            const newTokens = [];
-
-            if (currentToken.type !== "html_block") {
-                continue;
-            }
-
-            const content = currentToken.content;
-
-            // Process for each math referenced within the html block
-            for (const match of content.matchAll(mathRegex)) {
-                const html_before_math = match.groups.html_before_math;
-                const math = match.groups.math;
-                const html_after_math = match.groups.html_after_math;
-
-                if (html_before_math) {
-                    newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_before_math });
-                }
-
-                if (math) {
-                    newTokens.push({ 
-                        ...currentToken,
-                        type: mathType,
-                        map: null,
-                        content: math,
-                        markup: mathMarkup,
-                        block: true,
-                        tag: "math",
-                    });
-                }
-
-                if (html_after_math) {
-                    newTokens.push({ ...currentToken, type: "html_block", map: null, content: html_after_math });
-                }
-            }    
-            
-            // Replace the original html_block token with the newly expanded tokens
-            if (newTokens.length > 0) {
-                tokens.splice(index, 1, ...newTokens);
-            }
-        }    
-        return true;
+    if (enableMathInlineInHtml) {    
+        md.core.ruler.push("math_inline_in_html_block", (state) => {
+            return handleMathInHtml(state, "math_inline", "$", math_inline_within_html_regex);
+        });
     }
 
     md.renderer.rules.math_inline = inlineRenderer;

--- a/test/all.js
+++ b/test/all.js
@@ -16,8 +16,8 @@ testLoad(path.join(__dirname, 'fixtures/default.txt'), function (data) {
 		tape(fixture.header, function (t) {
 			t.plan(1);
 
-			const expected = fixture.second.text;
-			const actual = md.render(fixture.first.text);
+			const expected = normalizeWithStub(fixture.second.text);
+			const actual = normalizeWithStub(md.render(fixture.first.text));
 
 			t.equals(actual, expected);
 		});
@@ -36,10 +36,47 @@ testLoad(path.join(__dirname, 'fixtures/bare.txt'), function (data) {
 		tape(fixture.header, function (t) {
 			t.plan(1);
 
-			const expected = fixture.second.text;
-			const actual = md.render(fixture.first.text);
+			const expected = normalizeWithStub(fixture.second.text);
+			const actual = normalizeWithStub(md.render(fixture.first.text));
 
 			t.equals(actual, expected);
 		});
 	});
 });
+
+testLoad(path.join(__dirname, 'fixtures/math-in-html.txt'), function (data) {
+	const md = require('markdown-it')({
+			html: true
+		})
+		.use(mdk, {
+			enableMathBlockInHtml: true,
+			enableMathInlineInHtml: true
+		});
+
+	data.fixtures.forEach(function (fixture) {
+
+		/* generic test definition code using tape */
+		tape(fixture.header, function (t) {
+			t.plan(1);
+
+			const expected = normalizeWithStub(fixture.second.text);
+			const actual = normalizeWithStub(md.render(fixture.first.text));
+
+			t.equals(actual, expected);
+		});
+	});
+});
+
+// Replace differences between OS (Linux vs Windows) with stubs as we are not testing those specific
+// values for these tests.
+const normalizeWithStub = (text) => {
+	// ex: style="height:1.6667em;..." => style=""
+	text = text.replaceAll(/style=\".*?\"/g, "style=\"\"");
+
+	// ex: rowspacing="0.1600em" => rowspacing="1.0em"
+	text = text.replaceAll(/=\"\d+\.?\d*em\"/g, "=\"1.0em\"");
+
+	// ex: <svg...></svg> => <svg></svg>
+	text = text.replaceAll(/<svg[\s\S]*?><\/svg>/gm, "<svg></svg>");
+	return text;
+}

--- a/test/fixtures/math-in-html.txt
+++ b/test/fixtures/math-in-html.txt
@@ -1,0 +1,117 @@
+Math block in html
+.
+start
+
+<ol>
+    <li>$$x$$</li>
+</ol>
+
+end
+.
+<p>start</p>
+<ol>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></span></p>
+</li>
+</ol>
+<p>end</p>
+.
+
+Math inline in html
+.
+start
+
+<ol>
+    <li>$x$</li>
+</ol>
+
+end
+.
+<p>start</p>
+<ol>
+    <li><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></li>
+</ol>
+<p>end</p>
+.
+
+Math inline and math block in same html
+.
+start
+
+<ol>
+    <li>$x$</li>
+    <li>$$y$$</li>
+</ol>
+
+end
+.
+<p>start</p>
+<ol>
+    <li><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></li>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>y</mi></mrow><annotation encoding="application/x-tex">y</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal" style="">y</span></span></span></span></span></p>
+</li>
+</ol>
+<p>end</p>
+.
+
+Two math block in same html
+.
+start
+
+<ol>
+    <li>$$x$$</li>
+    <li>$$y$$</li>
+</ol>
+
+end
+.
+<p>start</p>
+<ol>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></span></p>
+</li>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>y</mi></mrow><annotation encoding="application/x-tex">y</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal" style="">y</span></span></span></span></span></p>
+</li>
+</ol>
+<p>end</p>
+.
+
+Two math inline in same html
+.
+start
+
+<ol>
+    <li>$x$</li>
+    <li>$y$</li>
+</ol>
+
+end
+.
+<p>start</p>
+<ol>
+    <li><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></li>
+    <li><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>y</mi></mrow><annotation encoding="application/x-tex">y</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal" style="">y</span></span></span></span></li>
+</ol>
+<p>end</p>
+.
+
+Two math block in two different html
+.
+<ol>
+    <li>$$x$$</li>
+</ol>
+
+middle
+
+<ol>
+    <li>$$y$$</li>
+</ol>
+.
+<ol>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>x</mi></mrow><annotation encoding="application/x-tex">x</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal">x</span></span></span></span></span></p>
+</li>
+</ol>
+<p>middle</p>
+<ol>
+    <li><p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>y</mi></mrow><annotation encoding="application/x-tex">y</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style=""></span><span class="mord mathnormal" style="">y</span></span></span></span></span></p>
+</li>
+</ol>
+.


### PR DESCRIPTION
Add support to render math defined inside html. Specifically, we should be able to render math blocks and math inline defined in html content.

For example, this should now render correctly as math within html.

```
<ol>
    <li>$$  H = \Large\sum_{i} w_{i}x_{i} + \sum_{i,j} w_{i,j}x_{i}x_{j} $$</li>
</ol>
```

Introduced 2 flags to be able to control whether to support math blocks and math inline (enableMathBlockInHtml and enableMathInlineInHtml).

Added tests for new support and made a tweak to stub out the values that we are not specifically testing by these katex tests so that we could run the tests on Windows and Linux.